### PR TITLE
`llama-index-callbacks-argilla` added to pypi's dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
     "argilla >= 1.22.0",
     "llama-index >= 0.10.0",
     "packaging >= 23.2",
-    "typing-extensions >= 4.3.0"
+    "typing-extensions >= 4.3.0",
+    llama-index-callbacks-argilla >= 0.1.4,
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "llama-index >= 0.10.0",
     "packaging >= 23.2",
     "typing-extensions >= 4.3.0",
-    llama-index-callbacks-argilla >= 0.1.4,
+    "llama-index-callbacks-argilla >= 0.1.4",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Closes #21 

Together with the tutorial I'm finishing, I'll make a new release. This PR will avoid the need of using `pip install llama-index-callbacks-argilla`